### PR TITLE
Fix playback device name parsing

### DIFF
--- a/EnableBassBoost.ps1
+++ b/EnableBassBoost.ps1
@@ -171,6 +171,8 @@ if (-not $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Adm
             if($MyInvocation.BoundParameters[$key]) {
                 $arguments += " -$key"
             }
+        } elseif (($MyInvocation.BoundParameters[$key].GetType()) -eq [string]) {
+            $arguments += " -$key `"$($MyInvocation.BoundParameters[$key])`""
         } else {
             $arguments += " -$key " + $MyInvocation.BoundParameters[$key]
         }


### PR DESCRIPTION
Tried to run the script but ran into a problem setting the playbackDeviceName parameter. The problem was that currently only device names that are not multiple words can continue script execution (my device name is separated with space "BenQ GW2480"). P.S. I don't write PowerShell scripts, I just tried to debug and found the place where the problem occurs. Btw thanks for the script 😉